### PR TITLE
Fix panic when using tags

### DIFF
--- a/octohug.go
+++ b/octohug.go
@@ -155,7 +155,7 @@ func visit(path string, fileInfo os.FileInfo, err error) error {
 				}
 				hugoFileWriter.WriteString("\"" + matches[1] + "\"")
 				firstTagAdded = true
-			} else {
+			} else if matches != nil {
 				tag := strings.Replace(matches[1], "'", "", -1)
 				tag = strings.Replace(tag, "\"", "", -1)
 				hugoFileWriter.WriteString("\"" + tag + "\"")


### PR DESCRIPTION
Before this patch it was bombing out with:
```
panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
main.visit({0x14000016d80, 0x40}, {0x1026579a8?, 0x140001008f0?}, {0x14000016d80?, 0x40?})
	/Users/danp/git/octohug/octohug.go:161 +0xd8c
path/filepath.walk({0x14000016d80, 0x40}, {0x1026579a8, 0x140001008f0}, 0x102656808)
	/opt/homebrew/Cellar/go/1.22.1/libexec/src/path/filepath/path.go:478 +0xc8
path/filepath.walk({0x10260c87b, 0xd}, {0x1026579a8, 0x14000100820}, 0x102656808)
	/opt/homebrew/Cellar/go/1.22.1/libexec/src/path/filepath/path.go:502 +0x1d0
path/filepath.Walk({0x10260c87b, 0xd}, 0x102656808)
	/opt/homebrew/Cellar/go/1.22.1/libexec/src/path/filepath/path.go:560 +0x6c
main.main()
	/Users/danp/git/octohug/octohug.go:237 +0xf4
```

On a posts which has the format:
```
categories:
- one
- two
tags:
- converted
sidebar: collapse
comments: true
```

And it seemed to match the sidebar line here.

I haven't fully understood how this was supposed to be working before/how my post format was wrong, but this fix allows it to run and seems to do the right thing